### PR TITLE
add Makanai app genarator.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,7 @@ Metrics/ClassLength:
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
+    - 'lib/makanai/rake_tasks.rb'
 
 Style/ParallelAssignment:
   Enabled: false

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ Makanai depends on the following, so please install it in advance.
 Getting started with Makanai is easy.
 
 ```
-$ git clone https://github.com/Madogiwa0124/makanai.git
-$ bundle install
-$ cd makanai/sample
-$ be ruby app.rb
+$ mkdir sample
+$ cd sample
+$ makanai init
+$ ruby app.rb
 [2019-11-08 21:46:37] INFO  WEBrick 1.4.2
 [2019-11-08 21:46:37] INFO  ruby 2.6.5 (2019-10-01) [x86_64-darwin18]
 [2019-11-08 21:46:37] INFO  WEBrick::HTTPServer#start: pid=45946 port=8080

--- a/exe/makanai
+++ b/exe/makanai
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+
+require 'makanai'
+require 'makanai/rake_tasks'
+
+if ARGV[0] == 'init'
+  Rake::Task['makanai:initialize:app'].execute
+end

--- a/lib/makanai.rb
+++ b/lib/makanai.rb
@@ -1,6 +1,10 @@
 require "makanai/version"
 
 module Makanai
+  def self.root
+    File.dirname __dir__
+  end
+
   class Error < StandardError; end
   # Your code goes here...
 end

--- a/lib/makanai/generator.rb
+++ b/lib/makanai/generator.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'erb'
+require 'yaml'
+require_relative '../makanai.rb'
+
+module Makanai
+  class Generator
+    ROOT_PATH = "#{Makanai.root}/lib/makanai/generator"
+    DIRECTORY_NAMES = YAML.load_file("#{ROOT_PATH}/application/directories.yaml")
+    APP_TEMPLATE = File.read("#{ROOT_PATH}/application/templates/app.erb")
+    RAKEFILE_TEMPLATE = File.read("#{ROOT_PATH}/application/templates/rakefile.erb")
+
+    def initialize(path = Dir.pwd)
+      @path = path
+    end
+
+    attr_reader :path
+
+    def create_app_directories(directory_names = DIRECTORY_NAMES)
+      directory_names.map do |name|
+        dir_path = File.join(path, name)
+        Dir.mkdir(dir_path)
+        file_path = File.join(dir_path, '.keep')
+        create_file(file_path, nil)
+        file_path
+      end
+    end
+
+    def create_app_rb(template = APP_TEMPLATE)
+      File.join(path, 'app.rb').tap do |file_path|
+        create_file(file_path, ERB.new(template).result)
+      end
+    end
+
+    def create_rakefile(template = RAKEFILE_TEMPLATE)
+      File.join(path, 'Rakefile').tap do |file_path|
+        create_file(file_path, ERB.new(template).result)
+      end
+    end
+
+    private
+
+    def create_file(file_path, content)
+      File.open(file_path, 'w') { |f| f.puts content }
+    end
+  end
+end

--- a/lib/makanai/generator/application/directories.yaml
+++ b/lib/makanai/generator/application/directories.yaml
@@ -1,0 +1,4 @@
+- db
+- migration
+- models
+- views

--- a/lib/makanai/generator/application/templates/app.erb
+++ b/lib/makanai/generator/application/templates/app.erb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'makanai/main'
+
+router.get '/' do
+  'Hello Makanai!'
+end

--- a/lib/makanai/generator/application/templates/rakefile.erb
+++ b/lib/makanai/generator/application/templates/rakefile.erb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require 'makanai/rake_tasks.rb'

--- a/lib/makanai/rake_tasks.rb
+++ b/lib/makanai/rake_tasks.rb
@@ -3,8 +3,21 @@
 require 'rake'
 require 'sqlite3'
 require_relative './migration.rb'
+require_relative './generator.rb'
 
 namespace :makanai do
+  namespace :initialize do
+    desc 'create directies and files for makanai initialization.'
+    task :app do
+      generator = Makanai::Generator.new
+      puts 'INFO: start ganerate app'
+      puts generator.create_app_directories
+      puts generator.create_app_rb
+      puts generator.create_rakefile
+      puts 'INFO: finished ganerate app'
+    end
+  end
+
   namespace :db do
     desc 'execute migration'
     task :migration do

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'makanai/generator'
+
+RSpec.describe Makanai::Generator do
+  before do
+    allow(File).to receive(:open).and_return('called File.open')
+    allow(Dir).to receive(:mkdir).and_return('called Dir.mkdir')
+  end
+
+  describe '#create_app_directories' do
+    let(:generator) { Makanai::Generator.new('/') }
+
+    it 'return created keep path in directries.' do
+      result = generator.create_app_directories
+      expect(result).to match_array [
+        File.join('/', 'db', '.keep'),
+        File.join('/', 'views', '.keep'),
+        File.join('/', 'models', '.keep'),
+        File.join('/', 'migration', '.keep')
+      ]
+    end
+  end
+
+  describe '#create_app_rb' do
+    let(:generator) { Makanai::Generator.new('/') }
+
+    it 'return created app file path.' do
+      result = generator.create_app_rb
+      expect(result).to eq File.join('/', 'app.rb')
+    end
+  end
+
+  describe '#create_rakefile' do
+    let(:generator) { Makanai::Generator.new('/') }
+
+    it 'return created Rakefile path.' do
+      result = generator.create_rakefile
+      expect(result).to eq File.join('/', 'Rakefile')
+    end
+  end
+end


### PR DESCRIPTION
Added `makanai init` command for initialize makanai application.

```
$ mkdir sample
$ cd sample
$ makanai init
$ ruby app.rb
[2019-11-08 21:46:37] INFO  WEBrick 1.4.2
[2019-11-08 21:46:37] INFO  ruby 2.6.5 (2019-10-01) [x86_64-darwin18]
[2019-11-08 21:46:37] INFO  WEBrick::HTTPServer#start: pid=45946 port=8080
```

`makanai init` create the following files:

```
INFO: start ganerate app
makanai_sample/db/.keep
makanai_sample/migration/.keep
makanai_sample/models/.keep
makanai_sample/views/.keep
makanai_sample/app.rb
makanai_sample/Rakefile
INFO: finished ganerate app
```
