### PR TITLE
Added support for dynamic URL routing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 ---
+env:
+  - CODECOV_TOKEN="3fec95fd-8b9d-43fa-ad3c-d792445d5a3a"
 language: ruby
 cache: bundler
 services:

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,5 @@ source 'https://rubygems.org'
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gemspec
+
+gem 'codecov', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,8 +10,14 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
+    codecov (0.1.16)
+      json
+      simplecov
+      url
     diff-lcs (1.3)
+    docile (1.3.2)
     jaro_winkler (1.5.4)
+    json (2.3.0)
     mysql2 (0.5.3)
     parallel (1.19.1)
     parser (2.7.0.4)
@@ -43,14 +49,20 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
     ruby-progressbar (1.10.1)
+    simplecov (0.18.5)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.2)
     sqlite3 (1.4.2)
     unicode-display_width (1.6.1)
+    url (0.3.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   bundler (~> 2.0)
+  codecov
   makanai!
   mysql2 (~> 0.5)
   pg (~> 1.2)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Gem Version](https://badge.fury.io/rb/makanai.svg)](https://badge.fury.io/rb/makanai)
 [![Build Status](https://travis-ci.com/Madogiwa0124/makanai.svg?branch=master)](https://travis-ci.com/Madogiwa0124/makanai)
+[![codecov](https://codecov.io/gh/Madogiwa0124/makanai/branch/master/graph/badge.svg)](https://codecov.io/gh/Madogiwa0124/makanai)
 
 simple web application framework for learning.
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Makanai::Settings.databse_config = {
 ```
 
 ## routing
+Routing is searched in the order defined and call block args.
 
 ``` ruby
 require 'makanai/main'
@@ -138,6 +139,12 @@ end
 # enable access to /params with get parameter
 router.get '/check' do |request|
   request.params['hoge']
+end
+
+# enable access to /hoge/:id with dinamic url args({ 'id' => '1'})
+# NOTE: dinamics prefix is `:`.
+router.get '/hoge/:id' do
+  request.params['id']
 end
 
 # enable access to /resources with method post and redirect other url.

--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ router.get '/hoge' do
   'Hello Hoge!'
 end
 
-# enable access to /params with get parameter
-router.get '/check' do |request|
+# enable access to /hoge with get parameter(?hoge=fuga)
+router.get '/hoge' do |request|
   request.params['hoge']
 end
 

--- a/lib/makanai/application.rb
+++ b/lib/makanai/application.rb
@@ -38,7 +38,10 @@ module Makanai
     private
 
     def execute_route
-      router.bind!(url: request.url, method: request.method).process.call(request)
+      route = router.bind!(url: request.url, method: request.method)
+      # NOTE: merge dynamic url params (ex. /resources/1 -> { 'id' => '1' })
+      @request.params.merge!(route.url_args)
+      route.process.call(request)
     rescue Makanai::Router::NotFound
       @response.status = 404
       nil

--- a/lib/makanai/request.rb
+++ b/lib/makanai/request.rb
@@ -6,7 +6,8 @@ require 'uri'
 
 module Makanai
   class Request < Rack::Request
-    attr_reader :env, :url, :query, :origin_body, :method, :params
+    attr_reader :env, :url, :query, :origin_body, :method
+    attr_accessor :params
 
     def initialize(env)
       super

--- a/lib/makanai/router.rb
+++ b/lib/makanai/router.rb
@@ -30,19 +30,50 @@ module Makanai
 
     def bind!(url:, method:)
       path = URI.parse(url).path
-      routes.find { |route| route.path == path && route.method == method }.tap do |route|
+      routes.find { |route| route.match?(path: path, method: method) }.tap do |route|
         raise NotFound if route.nil?
       end
     end
 
     class Route
+      DYNAMIC_PREFIX = ':' # Prefix for dynamic path
+
       def initialize(path:, process:, method:)
         @path = path
         @process = process
         @method = method
+        @url_args = {}
       end
 
-      attr_reader :path, :process, :method
+      attr_reader :path, :process, :method, :url_args
+
+      def match?(path:, method:)
+        build_url_args(path: path)
+        path_match?(path) && self.method == method
+      end
+
+      private
+
+      def dynamic_indx
+        @dynamic_indx ||= path.split('/').map.with_index do |val, i|
+          i if val.include?(DYNAMIC_PREFIX)
+        end.compact
+      end
+
+      def path_match?(path)
+        request_path, route_path = [path, self.path].map(&->(array) { array.split('/') })
+        request_path.each.with_index do |val, i|
+          route_path[i] = val if dynamic_indx.include?(i)
+        end
+        route_path == request_path
+      end
+
+      def build_url_args(path:)
+        request_path, route_path = [path, self.path].map(&->(array) { array.split('/') })
+        dynamic_indx.each do |i|
+          @url_args.merge!({ route_path[i].gsub(DYNAMIC_PREFIX, '') => request_path[i] })
+        end
+      end
     end
   end
 end

--- a/spec/application_spec.rb
+++ b/spec/application_spec.rb
@@ -18,6 +18,19 @@ RSpec.describe Makanai::Application do
       expect(response.body).to eq 'Hello World!'
     end
 
+    context 'binded dinamics url route' do
+      let(:response) { Rack::MockRequest.new(app).get('/foo/1') }
+      before { router.get('/foo/:id') { |req| "Hello Foo id:#{req.params['id']}!" } }
+
+      it 'Response Successed' do
+        expect(response.status).to eq 200
+      end
+
+      it 'return message with dinamics url parameter' do
+        expect(response.body).to eq 'Hello Foo id:1!'
+      end
+    end
+
     context 'has query parameter' do
       let(:response) { Rack::MockRequest.new(app).get('/hello?message=Makanai') }
       before { router.get('/hello') { |req| "Hello #{req.params['message']}!" } }

--- a/spec/router_spec.rb
+++ b/spec/router_spec.rb
@@ -49,11 +49,35 @@ RSpec.describe Makanai::Router do
     let(:router) { Makanai::Router.new }
 
     context 'found route' do
-      before { router.get('/') { 'Hello World' } }
+      context 'root path' do
+        before { router.get('/') { 'Hello World' } }
 
-      it 'return found route object' do
-        route = router.bind!(url: '/', method: 'GET')
-        expect(route.process.call).to eq 'Hello World'
+        it 'return found route object' do
+          route = router.bind!(url: '/', method: 'GET')
+          expect(route.process.call).to eq 'Hello World'
+        end
+      end
+
+      context 'with dinamic path' do
+        context 'with :id' do
+          before { router.get('/resouces/:id') { 'Hello World' } }
+
+          it 'return found route object' do
+            route = router.bind!(url: '/resouces/1', method: 'GET')
+            expect(route.url_args).to eq({ 'id' => '1' })
+            expect(route.process.call).to eq 'Hello World'
+          end
+        end
+
+        context 'with :parent_id, :id' do
+          before { router.get('/parents/:parent_id/children/:id') { 'Hello World' } }
+
+          it 'return found route object' do
+            route = router.bind!(url: '/parents/1/children/2', method: 'GET')
+            expect(route.url_args).to eq({ 'parent_id' => '1', 'id' => '2' })
+            expect(route.process.call).to eq 'Hello World'
+          end
+        end
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,12 @@
 require 'bundler/setup'
 require 'makanai'
 
+require 'simplecov'
+SimpleCov.start
+
+require 'codecov'
+SimpleCov.formatter = SimpleCov::Formatter::Codecov
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
example

``` ruby
router.get '/hoge/:id' do
  request.params['id']
end
```

Routing is searched in the order defined and call block args.

``` ruby
=begin
Bad :-1
Dynamic URL is bound first and fuga cannot be executed
=end

router.get '/hoge/:id' do
  request.params['id']
end

router.get '/hoge/fuga' do
  'fuga'
end

=begin
Good :+1
=end
router.get '/hoge/fuga' do
  'fuga'
end

router.get '/hoge/:id' do
  request.params['id']
end
```