### PR TITLE
:sparkles: changeable template engine.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,9 @@ GEM
       url
     diff-lcs (1.3)
     docile (1.3.2)
+    haml (5.1.2)
+      temple (>= 0.8.0)
+      tilt
     json (2.3.0)
     mysql2 (0.5.3)
     parallel (1.19.1)
@@ -57,6 +60,8 @@ GEM
       simplecov-html (~> 0.11)
     simplecov-html (0.12.2)
     sqlite3 (1.4.2)
+    temple (0.8.2)
+    tilt (2.0.10)
     unicode-display_width (1.7.0)
     url (0.3.2)
 
@@ -66,6 +71,7 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 2.0)
   codecov
+  haml (~> 5.0)
   makanai!
   mysql2 (~> 0.5)
   pg (~> 1.2)

--- a/README.md
+++ b/README.md
@@ -169,21 +169,32 @@ router.delete '/resources' do |request|
 end
 ```
 
-## erb render
+## rendering
 
-Define instance variables used in the routing view.
+Define instance variables used in the routing view. And specify template engine(`ERB` or `Haml`).
 
 ``` ruby
 require 'makanai/main'
 
+# setting template engine(default: :erb).
+Makanai::Settings.template_engine = :haml
+
 router.get '/index' do
   @title = 'Makanai title'
   @body = 'Makanai body'
-  render :index
+  render :index # render default template engine.
+end
+
+router.get '/index' do
+  @title = 'Makanai title'
+  @body = 'Makanai body'
+  render :index, :haml # render specified template engine.
 end
 ```
 
 Create an erb file in `src/views` with the name specified in render.
+
+erb
 
 ``` html
 <!-- src/views/index.erb -->
@@ -196,6 +207,19 @@ Create an erb file in `src/views` with the name specified in render.
   <%= @body %>
 </body>
 </html>
+```
+
+haml
+
+``` haml
+!!!
+%html
+  %head
+    %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
+    %meta{:charset => "UTF-8"}/
+    %title= @title
+  %body
+    = @body
 ```
 
 ## migration

--- a/lib/makanai/dsl.rb
+++ b/lib/makanai/dsl.rb
@@ -4,10 +4,12 @@ require_relative './template.rb'
 require_relative './response.rb'
 require_relative './settings.rb'
 
-def render(path)
+def render(path, engine = Makanai::Settings.template_engine)
   template_root_path = Makanai::Settings.template_full_path
-  full_path = File.join(template_root_path, "#{path}.erb")
-  Makanai::Template.new(path: full_path).render
+  full_path = File.join(template_root_path, path.to_s)
+  # NOTE: Get all instance variables in main by Hash
+  locals = instance_variables.map { |name| [name, instance_variable_get(name)] }.to_h
+  Makanai::Template.new(path: full_path, engine: engine, locals: locals).render
 end
 
 def redirect_to(url)

--- a/lib/makanai/settings.rb
+++ b/lib/makanai/settings.rb
@@ -11,10 +11,12 @@ module Makanai
     DEFAULT_TEMPLATE_ROOT_PATH = '/views/'
     DEFAULT_MIGRATION_ROOT_PATH = '/migration/'
     DEFAULT_RACK_APP_CONFIG = { handler: :webrick, host: '0.0.0.0', port: '8080' }.freeze
+    DEFAULT_TEMPLATE_ENGINE = :erb
 
     @app_root_path = DEFAULT_APP_ROOT_PATH
     @database_path = DEFAULT_DATABASE_PATH
     @template_root_path = DEFAULT_TEMPLATE_ROOT_PATH
+    @template_engine = DEFAULT_TEMPLATE_ENGINE
     @migration_root_path = DEFAULT_MIGRATION_ROOT_PATH
     @rack_app_config = DEFAULT_RACK_APP_CONFIG
 
@@ -45,6 +47,7 @@ module Makanai
       attr_accessor :app_root_path,
                     :database_path,
                     :template_root_path,
+                    :template_engine,
                     :migration_root_path,
                     :rack_app_config,
                     :databse_client,

--- a/lib/makanai/template.rb
+++ b/lib/makanai/template.rb
@@ -1,18 +1,29 @@
 # frozen_string_literal: true
 
-require 'erb'
-
 module Makanai
   class Template
-    def initialize(path:)
+    class UnsupportedException < StandardError; end
+
+    def initialize(path:, engine: :erb, locals: {})
       @path = path
+      @engine = engine
+      @locals = locals
     end
 
-    attr_reader :path
+    attr_reader :path, :engine, :locals
 
     def render
-      template_file = File.read(path)
-      ERB.new(template_file).result
+      template_file = File.read("#{path}.#{engine}")
+      engine_class.new(text: template_file, locals: locals).result
+    end
+
+    private
+
+    def engine_class
+      require_relative File.join('template_engine', engine.to_s)
+      Object.const_get("Makanai::TemplateEngine::#{engine.capitalize}")
+    rescue LoadError
+      raise UnsupportedException
     end
   end
 end

--- a/lib/makanai/template_engine/base.rb
+++ b/lib/makanai/template_engine/base.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Makanai
+  module TemplateEngine
+    class Base
+      def result
+        raise NotImplementedError
+      end
+    end
+  end
+end

--- a/lib/makanai/template_engine/erb.rb
+++ b/lib/makanai/template_engine/erb.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'erb'
+require 'ostruct'
+require_relative './base'
+
+module Makanai
+  module TemplateEngine
+    class Erb < Base
+      def initialize(text:, locals: {})
+        @text = text
+        @locals = locals
+      end
+
+      attr_reader :text, :locals
+
+      def result
+        # NOTE: ERB is need to pass the binding.
+        # So, pass the binding of the object that defined the instance variable.
+        # ref: https://docs.ruby-lang.org/en/2.7.0/ERB.html#method-i-result
+        ERB.new(text).result(Locals.new(locals).self_binding)
+      end
+      class Locals
+        def initialize(locals)
+          locals.each { |key, val| instance_variable_set(key, val) }
+        end
+
+        def self_binding
+          binding
+        end
+      end
+
+      private_constant :Locals
+    end
+  end
+end

--- a/lib/makanai/template_engine/haml.rb
+++ b/lib/makanai/template_engine/haml.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'haml'
+require_relative './base'
+
+module Makanai
+  module TemplateEngine
+    class Haml < Base
+      def initialize(text:, locals: {})
+        @text = text
+        @locals = locals
+      end
+
+      attr_reader :text, :locals
+
+      def result
+        # ref: http://haml.info/docs/yardoc/Haml/Engine.html#render-instance_method
+        ::Haml::Engine.new(text).render(Object.new, locals)
+      end
+    end
+  end
+end

--- a/makanai.gemspec
+++ b/makanai.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pg", "~> 1.2"
   spec.add_development_dependency "mysql2", "~> 0.5"
+  spec.add_development_dependency "haml", "~> 5.0"
 end

--- a/spec/sample/app.rb
+++ b/spec/sample/app.rb
@@ -21,6 +21,12 @@ router.get '/index' do
   render :index
 end
 
+router.get '/index/haml' do
+  @title = 'Makanai title'
+  @body = 'Makanai body'
+  render :index, :haml
+end
+
 router.get '/numbers' do
   @title = 'numbers'
   @numbers = Number.all

--- a/spec/sample/views/index.haml
+++ b/spec/sample/views/index.haml
@@ -1,0 +1,8 @@
+!!!
+%html
+  %head
+    %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
+    %meta{:charset => "UTF-8"}/
+    %title= @title
+  %body
+    = @body

--- a/spec/template_engine/base_spec.rb
+++ b/spec/template_engine/base_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'makanai/template_engine/base'
+
+RSpec.describe Makanai::TemplateEngine::Base do
+  describe '#result' do
+    it 'raise NotImplementedError' do
+      engine = Makanai::TemplateEngine::Base.new
+      expect { engine.result }.to raise_error NotImplementedError
+    end
+  end
+end

--- a/spec/template_engine/erb_spec.rb
+++ b/spec/template_engine/erb_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'makanai/template_engine/erb'
+
+RSpec.describe Makanai::TemplateEngine::Erb do
+  describe '#result' do
+    let(:text) { '<span><%= @foo %></span>' }
+    let(:locals) { { :@foo => 'foo' } }
+
+    it 'return parsed erb text' do
+      result = Makanai::TemplateEngine::Erb.new(text: text, locals: locals).result
+      expect(result).to eq '<span>foo</span>'
+    end
+  end
+end

--- a/spec/template_engine/haml_spec.rb
+++ b/spec/template_engine/haml_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'makanai/template_engine/haml'
+
+RSpec.describe Makanai::TemplateEngine::Haml do
+  describe '#result' do
+    let(:locals) { { :@foo => 'foo' } }
+    let(:text) { '%span= @foo' }
+
+    it 'return parsed haml text' do
+      result = Makanai::TemplateEngine::Haml.new(text: text, locals: locals).result
+      expect(result).to eq "<span>foo</span>\n"
+    end
+  end
+end

--- a/spec/template_spec.rb
+++ b/spec/template_spec.rb
@@ -12,5 +12,13 @@ RSpec.describe Makanai::Template do
     it 'return parsed erb text' do
       expect(template.render).to eq 'result: 2'
     end
+
+    context 'not support engine' do
+      let(:template) { Makanai::Template.new(path: 'test.erb', engine: :not_support) }
+
+      it 'raise UnsupportedException' do
+        expect { template.render }.to raise_error Makanai::Template::UnsupportedException
+      end
+    end
   end
 end


### PR DESCRIPTION
enabled to switch template engine Haml and ERB.

``` ruby
router.get '/index' do
  @title = 'Makanai title'
  @body = 'Makanai body'
  render :index, :haml # render haml template
end

Makanai::Settings.template_engine = :haml

router.get '/index' do
  @title = 'Makanai title'
  @body = 'Makanai body'
  render :index # render haml template by default engine
end
```