### PR TITLE
:scissors: remove sqlite3 from runtime_dependency.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,6 @@ PATH
     makanai (0.1.5)
       rack (>= 2.0.7, < 2.3.0)
       rake (>= 10, < 14)
-      sqlite3 (~> 1.4.1)
 
 GEM
   remote: https://rubygems.org/
@@ -77,6 +76,7 @@ DEPENDENCIES
   pg (~> 1.2)
   rspec (~> 3.0)
   rubocop (~> 0.74)
+  sqlite3 (~> 1.4.1)
 
 BUNDLED WITH
    2.1.4

--- a/README.md
+++ b/README.md
@@ -24,12 +24,6 @@ Or install it yourself as:
 
     $ gem install makanai
 
-## Dependencies
-
-Makanai depends on the following, so please install it in advance.
-
-* [SQLite3](https://www.sqlite.org/index.html)
-
 ## Start sample project
 Getting started with Makanai is easy.
 
@@ -101,9 +95,11 @@ Overwrite the `handler` in `rack_app_config` with the created ruby ​​file(ex
 Makanai::Settings.rack_app_config = { handler: :puma, host: '0.0.0.0', port: '8080' }
 ```
 
-### use other dbms
+### use dbms
 
-install dbms(postgresql, mysql, sqlite). And add dbms gem (ex. pg) in your Gemfile.
+Makanai use `sqlite` by default, and make `db/makanai.db`.
+
+If you use another dbms, install dbms(PostgreSQL or MySQL). And add dbms gem (`pg` or `mysql2`) in your Gemfile.
 
 ``` ruby
 gem 'pg'

--- a/lib/makanai/database.rb
+++ b/lib/makanai/database.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require_relative './dbms/sqlite'
 require_relative './settings'
 
 module Makanai

--- a/lib/makanai/generator.rb
+++ b/lib/makanai/generator.rb
@@ -10,6 +10,7 @@ module Makanai
     DIRECTORY_NAMES = YAML.load_file("#{ROOT_PATH}/application/directories.yaml")
     APP_TEMPLATE = File.read("#{ROOT_PATH}/application/templates/app.erb")
     RAKEFILE_TEMPLATE = File.read("#{ROOT_PATH}/application/templates/rakefile.erb")
+    GEMFILE_TEMPLATE = File.read("#{ROOT_PATH}/application/templates/gemfile.erb")
 
     def initialize(path = Dir.pwd)
       @path = path
@@ -35,6 +36,12 @@ module Makanai
 
     def create_rakefile(template = RAKEFILE_TEMPLATE)
       File.join(path, 'Rakefile').tap do |file_path|
+        create_file(file_path, ERB.new(template).result)
+      end
+    end
+
+    def create_gemfile(template = GEMFILE_TEMPLATE)
+      File.join(path, 'Gemfile').tap do |file_path|
         create_file(file_path, ERB.new(template).result)
       end
     end

--- a/lib/makanai/generator/application/templates/gemfile.erb
+++ b/lib/makanai/generator/application/templates/gemfile.erb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+gem 'makanai'
+gem 'sqlite3'

--- a/lib/makanai/rake_tasks.rb
+++ b/lib/makanai/rake_tasks.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rake'
-require 'sqlite3'
 require_relative './migration'
 require_relative './generator'
 
@@ -14,6 +13,7 @@ namespace :makanai do
       puts generator.create_app_directories
       puts generator.create_app_rb
       puts generator.create_rakefile
+      puts generator.create_gemfile
       puts 'INFO: finished ganerate app'
     end
   end
@@ -25,6 +25,7 @@ namespace :makanai do
 
       puts "INFO: start migration #{ENV['target']}"
       target = ENV['target']
+      pp migration_root_path
       if target == 'all'
         sql_paths = Dir.glob("#{migration_root_path}*")
         sql_paths.each { |sql_path| execute_sql(sql_path: sql_path) }

--- a/lib/makanai/settings.rb
+++ b/lib/makanai/settings.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require 'rack'
-require_relative './dbms/sqlite'
-require_relative './dbms/postgres'
 
 module Makanai
   class Settings

--- a/makanai.gemspec
+++ b/makanai.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rake", ">= 10", "< 14"
   spec.add_dependency "rack", ">= 2.0.7", "< 2.3.0"
-  spec.add_dependency "sqlite3", "~> 1.4.1"
+  spec.add_development_dependency "sqlite3", "~> 1.4.1"
   spec.add_development_dependency "rubocop", "~> 0.74"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -39,4 +39,13 @@ RSpec.describe Makanai::Generator do
       expect(result).to eq File.join('/', 'Rakefile')
     end
   end
+
+  describe '#create_gemfile' do
+    let(:generator) { Makanai::Generator.new('/') }
+
+    it 'return created Rakefile path.' do
+      result = generator.create_gemfile
+      expect(result).to eq File.join('/', 'Gemfile')
+    end
+  end
 end


### PR DESCRIPTION
Remove sqlite3 from runtime_dependency because it doesn't necessarily use the DB.