### PR TITLE
[ci skip] :gear: Upgrade to GitHub-native Dependabot.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: bundler
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "17:00"
+  open-pull-requests-limit: 10


### PR DESCRIPTION
[ci skip] :gear: Upgrade to GitHub-native Dependabot.